### PR TITLE
Close PRs when PR opened

### DIFF
--- a/.github/workflows/autoclose.yaml
+++ b/.github/workflows/autoclose.yaml
@@ -4,6 +4,7 @@ permissions:
   pull-requests: write
 
 on:
+  pull_request:
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:


### PR DESCRIPTION
Re: https://github.com/python/cpython-bin-deps/pull/5#issuecomment-2384653077

The cron was disabled four months ago:

> This scheduled workflow is disabled because there hasn't been activity in this repository for at least 60 days. Enable this workflow to resume scheduled runs.

This triggers the autoclose when opening a PR.

For a demo, see:

* https://github.com/hugovk/cpython-bin-deps/pull/2
* https://github.com/hugovk/cpython-bin-deps/actions/runs/11119605305/job/30895075878?pr=2

(This PR will be autoclosed the next time the schedule runs, we'll just have to re-open it before merge 😅)